### PR TITLE
Bug: Filter available on unique relationships close #15

### DIFF
--- a/engine/src/api/schema/fields.rs
+++ b/engine/src/api/schema/fields.rs
@@ -128,17 +128,23 @@ fn build_field_from_relationship<'r, S>(
 where
 	S: AsyncScalarValue,
 {
-	let field = if relationship.relationship_type.returns_array() {
+	let returns_array = relationship.relationship_type.returns_array();
+
+	let field = if returns_array {
 		registry.field::<Vec<Entity>>(relationship.name.as_str(), info)
 	} else {
 		registry.field::<Entity>(relationship.name.as_str(), info)
 	};
 
-	field
-		.argument(
-			registry.arg::<Option<EntityFilter<S>>>("where", &EntityFilterData::new(info.data)),
-		)
-		.argument(registry.arg::<Option<i32>>("limit", &()))
+	if returns_array {
+		field
+			.argument(
+				registry.arg::<Option<EntityFilter<S>>>("where", &EntityFilterData::new(info.data)),
+			)
+			.argument(registry.arg::<Option<i32>>("limit", &()))
+	} else {
+		field
+	}
 }
 
 impl<'a, S> GraphQLType<S> for Entity<'a>


### PR DESCRIPTION
### Description

This fixes a bug that happened whenever you create a relationship between two entities on which one of the arms of the relationship is a One, for example: ManyToOne, OneToMany, OneToOne, the Schema generated adds filtering for both arms which didn't make any sense to filter single entities.

### Components

- [x] GraphQL API

### Related issues

#15 

### Implementation

Checking whether the returning type of the relationship property on the entity is an array or not we add the filtering for that property.






